### PR TITLE
Set the update check settings to false about negativeKeywordsList and  googleAnalyticsData when cache setting is disable

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,9 @@ if(cache_path && fs.existsSync(cache_path)){
 	}else{
 		util.orverrideTmp([] , hexo);
 	}
+} else {
+	hexo.config.popularPosts.tmp.isNgwUpdate = false;
+	hexo.config.popularPosts.tmp.isGaUpdate = false;
 }
 
 hexo.extend.filter.register('after_init', require('./lib/googleAnalytics'), {async: true});


### PR DESCRIPTION
## Enviroment

* Operating system with version : Windows10 15063
* Node version : 6.11.1
* Hexo version : 3.4.1
* Hexo-cli version : 1.0.4

## Problem

Sometime below error occurs when save post file in developer mode (hexo server command), if hexo-related-popular-posts cache setting is disable.

```
Cannot read property 'path' of undefined
    at Object.module.exports.getList (D:\blog\1_main\node_modules\hexo-related-popular-posts\lib\list-json.js:41:80)
    at module.exports (D:\blog\1_main\node_modules\hexo-related-popular-posts\lib\helper-json.js:6:19)
    at Object.<anonymous> (D:\blog\1_main\node_modules\hexo-related-popular-posts\index.js:173:37)
    at Object.wrapper [as popular_posts_json] (D:\blog\1_main\node_modules\lodash\lodash.js:4968:19)
    at eval (eval at compile (D:\blog\1_main\node_modules\hexo-renderer-ejs\node_modules\ejs\lib\ejs.js:1:0), <anonymous>:89:29)
    at returnedFn (D:\blog\1_main\node_modules\hexo-renderer-ejs\node_modules\ejs\lib\ejs.js:580:17)
    at _compiledSync (D:\blog\1_main\node_modules\hexo\lib\theme\view.js:122:20)
    at View.renderSync (D:\blog\1_main\node_modules\hexo\lib\theme\view.js:50:21)
    at Object.partial (D:\blog\1_main\node_modules\hexo\lib\plugins\helper\partial.js:42:17)
    at Object.wrapper (D:\blog\1_main\node_modules\lodash\lodash.js:4968:19)
    at eval (eval at compile (D:\blog\1_main\node_modules\hexo-renderer-ejs\node_modules\ejs\lib\ejs.js:1:0), <anonymous>:9:17)
    at returnedFn (D:\blog\1_main\node_modules\hexo-renderer-ejs\node_modules\ejs\lib\ejs.js:580:17)
    at _compiled (D:\blog\1_main\node_modules\hexo\lib\theme\view.js:127:30)
    at View.render (D:\blog\1_main\node_modules\hexo\lib\theme\view.js:29:15)
    at D:\blog\1_main\node_modules\hexo\lib\hexo\index.js:390:25
    at tryCatcher (D:\blog\1_main\node_modules\hexo\node_modules\bluebird\js\release\util.js:16:23)
    at D:\blog\1_main\node_modules\hexo\node_modules\bluebird\js\release\method.js:15:34
    at RouteStream._read (D:\blog\1_main\node_modules\hexo\lib\hexo\router.js:134:3)
    at RouteStream.Readable.read (_stream_readable.js:348:10)
    at resume_ (_stream_readable.js:737:12)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
```

## Reason

In the current source code(index.js), update check default setting about negativeKeywordsList and  googleAnalyticsData are true. And these setting never change to false, if hexo-related-popular-posts cache setting is disable.

## Solution

Set the update check settings to false about negativeKeywordsList and  googleAnalyticsData when cache setting is disable.