### PR TITLE
Support sub-path URL configuration with popular posts feature

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,6 +6,7 @@ module.exports = ( hexo ) => {
     const lg         = require('./log.js')
     const su         = require('./settingsUpdate.js')
 
+    const root                    = hexo.config.root.slice(1)
     const cache_path              = hexo.config.popularPosts.tmp.cache_path
     const rankingSheet            = hexo.config.popularPosts.tmp.rankingSheet
     const pvMeasurementsStartDate = hexo.config.popularPosts.tmp.pvMeasurementsStartDate
@@ -33,7 +34,7 @@ module.exports = ( hexo ) => {
             // PV update
             if (hexo.config.popularPosts.tmp.isGaUpdate) {
                 for (let w=0; w<tmp_gaData.length; w++) {
-                    if (hexo.locals.cache.posts.data[v].popularPost_tmp_gaData.path == tmp_gaData[w].path) {
+                    if (root + hexo.locals.cache.posts.data[v].popularPost_tmp_gaData.path == tmp_gaData[w].path) {
                         hexo.locals.cache.posts.data[v].popularPost_tmp_gaData.pv = tmp_gaData[w].pv;
                         hexo.locals.cache.posts.data[v].popularPost_tmp_gaData.totalPV = tmp_gaData[w].totalPV;
                         break;


### PR DESCRIPTION
This pull request is to enhance the features of popular articles.
This enhances the behavior when the website is placed in the sub-path rather than at the top of the domain.

For example, when a website is placed on `https://example.com/sub/20019/04/18/title`, the feature of popular article works as follows and does not match.
-hexo-related-popular-posts: `2019/04/18/title`
-ga-analytics: `sub/2019/04/18/title`

Use Hexo's URL configuration `root` to enhance popular article functionality. This configuration includes setting up the website subpath.

Hexo URL settings ("Sub-path" is written as "subdirectory" in the Hexo documentation)
https://hexo.io/docs/configuration#URL


Thank you for developing a wonderful plugin.
This plugin is an innovation in the static site generator world! !