### PR TITLE
support hexo 5.0.0 (#26)

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -23,27 +23,27 @@ module.exports = ( hexo ) => {
     // load hexo@3.2's cache
     // --------------------------------------------
     // If the article is not updated, hexo internally caches the previous data (db.json).
-    if (hexo && hexo.locals && hexo.locals.cache.cache && hexo.locals.cache.cache.posts.length && hexo.locals.cache.cache.posts.data[0].popularPost_tmp_gaData && hexo.locals.cache.cache.posts.data[hexo.locals.cache.cache.posts.length - 1].popularPost_tmp_gaData) {
+    if (hexo && hexo.locals && hexo.locals.cache.cache && hexo.locals.cache.cache.get('posts').length && hexo.locals.cache.cache.get('posts').data[0].popularPost_tmp_gaData && hexo.locals.cache.cache.get('posts').data[hexo.locals.cache.cache.get('posts').length - 1].popularPost_tmp_gaData) {
         let tmp_gaData = hexo.config.popularPosts.tmp.gaData
         hexo.config.popularPosts.tmp.postPath = null
         hexo.config.popularPosts.tmp.postPath = []
         hexo.config.popularPosts.tmp.gaData   = null
         hexo.config.popularPosts.tmp.gaData   = []
 
-        for (let v=0; v<hexo.locals.cache.cache.posts.length; v++) {
+        for (let v=0; v<hexo.locals.cache.cache.get('posts').length; v++) {
             // PV update
             if (hexo.config.popularPosts.tmp.isGaUpdate) {
                 for (let w=0; w<tmp_gaData.length; w++) {
-                    if (root + hexo.locals.cache.cache.posts.data[v].popularPost_tmp_gaData.path == tmp_gaData[w].path) {
-                        hexo.locals.cache.cache.posts.data[v].popularPost_tmp_gaData.pv = tmp_gaData[w].pv;
-                        hexo.locals.cache.cache.posts.data[v].popularPost_tmp_gaData.totalPV = tmp_gaData[w].totalPV;
+                    if (root + hexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_gaData.path == tmp_gaData[w].path) {
+                        hexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_gaData.pv = tmp_gaData[w].pv;
+                        hexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_gaData.totalPV = tmp_gaData[w].totalPV;
                         break;
                     }
                 }
             }
 
-            hexo.config.popularPosts.tmp.gaData.push(hexo.locals.cache.cache.posts.data[v].popularPost_tmp_gaData)
-            if (hexo.locals.cache.cache.posts.data[v].popularPost_tmp_postPath)hexo.config.popularPosts.tmp.postPath.push(hexo.locals.cache.cache.posts.data[v].path)
+            hexo.config.popularPosts.tmp.gaData.push(hexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_gaData)
+            if (hexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_postPath)hexo.config.popularPosts.tmp.postPath.push(hexo.locals.cache.cache.get('posts').data[v].path)
         }
         gaData = hexo.config.popularPosts.tmp.gaData
         tmp_gaData = null
@@ -52,7 +52,7 @@ module.exports = ( hexo ) => {
     // -----------------------------------------------
     // When you use the hexo clean command, the internal cache of hexo is cleared.
     // In this case , merge the updated article data and plugin's cache data (e.g. hexo-rpp-cached.json).
-    } else if (hexo && hexo.locals && hexo.locals.cache.cache && hexo.locals.cache.cache.posts.length && !hexo.locals.cache.cache.posts.data[0].popularPost_tmp_gaData && cache_path) {
+    } else if (hexo && hexo.locals && hexo.locals.cache.cache && hexo.locals.cache.cache.get('posts').length && !hexo.locals.cache.cache.get('posts').data[0].popularPost_tmp_gaData && cache_path) {
         for (let i = 0; i < gaData.length; i++) {
             let matchedPath = true
             for (let k = 0; k < hexo.config.popularPosts.tmp.postPath.length; k++) {
@@ -66,7 +66,7 @@ module.exports = ( hexo ) => {
     // -----------------------------------------------
     // When you use the hexo clean command, the internal cache of hexo is cleared.
     // In this case , merge the postPath data
-    } else if (hexo && hexo.locals && hexo.locals.cache.cache && hexo.locals.cache.cache.posts.length && hexo.locals.cache.cache.posts.data[0].popularPost_tmp_gaData && !hexo.locals.cache.cache.posts.data[hexo.locals.cache.cache.posts.length - 1].popularPost_tmp_gaData) {
+    } else if (hexo && hexo.locals && hexo.locals.cache.cache && hexo.locals.cache.cache.get('posts').length && hexo.locals.cache.cache.get('posts').data[0].popularPost_tmp_gaData && !hexo.locals.cache.cache.get('posts').data[hexo.locals.cache.cache.get('posts').length - 1].popularPost_tmp_gaData) {
         if (hexo.config.popularPosts.tmp.postPath.length == 0) {
             for (let i = 0; i < gaData.length; i++) {
                 hexo.config.popularPosts.tmp.postPath.push(gaData[i].path)

--- a/lib/list-json.js
+++ b/lib/list-json.js
@@ -21,26 +21,26 @@ module.exports.getList = (inOptions, inPost, inHexo) => {
 
     // load hexo@3.2's cache
     // --------------------------------------------
-    if (!config.popularPosts.tmp.cache_path && inHexo && inHexo.locals && inHexo.locals.cache.cache && inHexo.locals.cache.cache.posts.length && inHexo.locals.cache.cache.posts.data[0].popularPost_tmp_gaData) {
+    if (!config.popularPosts.tmp.cache_path && inHexo && inHexo.locals && inHexo.locals.cache.cache && inHexo.locals.cache.cache.get('posts').length && inHexo.locals.cache.cache.get('posts').data[0].popularPost_tmp_gaData) {
         let tmp_gaData = config.popularPosts.tmp.gaData
         config.popularPosts.tmp.postPath = null
         config.popularPosts.tmp.postPath = []
         config.popularPosts.tmp.gaData   = null
         config.popularPosts.tmp.gaData   = []
-        for (let i = 0; i < inHexo.locals.cache.cache.posts.length; i++) {
+        for (let i = 0; i < inHexo.locals.cache.cache.get('posts').length; i++) {
             // PV update
             if (config.popularPosts.tmp.isGaUpdate) {
                 for (k=0; k<tmp_gaData.length; k++) {
-                    if (inHexo.locals.cache.cache.posts.data[i].popularPost_tmp_gaData.path == tmp_gaData[k].path) {
-                        inHexo.locals.cache.cache.posts.data[i].popularPost_tmp_gaData.pv = tmp_gaData[k].pv
-                        inHexo.locals.cache.cache.posts.data[i].popularPost_tmp_gaData.totalPV = tmp_gaData[k].totalPV
+                    if (inHexo.locals.cache.cache.get('posts').data[i].popularPost_tmp_gaData.path == tmp_gaData[k].path) {
+                        inHexo.locals.cache.cache.get('posts').data[i].popularPost_tmp_gaData.pv = tmp_gaData[k].pv
+                        inHexo.locals.cache.cache.get('posts').data[i].popularPost_tmp_gaData.totalPV = tmp_gaData[k].totalPV
                         break
                     }
                 }
             }
 
-            config.popularPosts.tmp.gaData.push(inHexo.locals.cache.cache.posts.data[i].popularPost_tmp_gaData)
-            if (inHexo.locals.cache.cache.posts.data[i].popularPost_tmp_postPath)config.popularPosts.tmp.postPath.push(inHexo.locals.cache.cache.posts.data[i].path)
+            config.popularPosts.tmp.gaData.push(inHexo.locals.cache.cache.get('posts').data[i].popularPost_tmp_gaData)
+            if (inHexo.locals.cache.cache.get('posts').data[i].popularPost_tmp_postPath)config.popularPosts.tmp.postPath.push(inHexo.locals.cache.cache.get('posts').data[i].path)
         }
         tmp_gaData = null
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -142,14 +142,14 @@ module.exports.orverrideTmp = (inGaData, inHexo) => {
     // load hexo@3.2's cache
     // ----------------------------------------------
     let isUseHexosCache = false
-    if (( !inGaData || inGaData == []) && inHexo && inHexo.locals && inHexo.locals.cache.cache && inHexo.locals.cache.cache.posts.length && inHexo.locals.cache.cache.posts.data[0].popularPost_tmp_gaData) {
+    if (( !inGaData || inGaData == []) && inHexo && inHexo.locals && inHexo.locals.cache.cache && inHexo.locals.cache.cache.get('posts').length && inHexo.locals.cache.cache.get('posts').data[0].popularPost_tmp_gaData) {
         isUseHexosCache = true
         gaData_tmp = null
         gaData_tmp = []
         let postPath_temp = []
-        for (let v=0; v<inHexo.locals.cache.cache.posts.length; v++) {
-            gaData_tmp.push(inHexo.locals.cache.cache.posts.data[v].popularPost_tmp_gaData)
-            if (inHexo.locals.cache.cache.posts.data[v].popularPost_tmp_postPath)postPath_temp.push(inHexo.locals.cache.cache.posts.data[v].path)
+        for (let v=0; v<inHexo.locals.cache.cache.get('posts').length; v++) {
+            gaData_tmp.push(inHexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_gaData)
+            if (inHexo.locals.cache.cache.get('posts').data[v].popularPost_tmp_postPath)postPath_temp.push(inHexo.locals.cache.cache.get('posts').data[v].path)
         }
 
         inHexo.config.popularPosts.tmp = Object.assign( {},

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "eslint": "^4.12.0",
     "eslint-config-google": "^0.9.1",
-    "hexo": "^4.2.0",
+    "hexo": "^5.0.0",
     "intelli-espower-loader": "^1.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",


### PR DESCRIPTION
# Description

fixes: #26

In hexo 5.0.0 hexo-util has been updated. Please see followings:

https://github.com/hexojs/hexo/pull/4438

https://github.com/hexojs/hexo-util/commit/f1ecd4e24cc431623f19644990e81487fea3bbf5

# Fix

hexo.locals.cache.posts to hexo.locals.cache.cache.get('posts')

# Others

I only test related post feature.

I didn't update the version, so you may have to update it by yourself.

Thank you (*^_^*)